### PR TITLE
Issue-#38: fixed imports and README.md files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GOOGLE_API_KEY="your_key_here"
+GOOGLE_MODEL=gemini-2.5-flash
+USE_GEMINI=True

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ env/
 # Python: Ignore compiled cache files
 __pycache__/
 *.pyc
+.pytest_cache/
 
 CLAUDE.md
+.claudeignore

--- a/README.md
+++ b/README.md
@@ -19,10 +19,30 @@ Convert SystemVerilog RTL into architecture diagrams using a multi-agent LLM pip
 
 ## Setup
 
+Create and activate a virtual environment:
+
+```bash
+# macOS / Linux
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+```powershell
+# Windows (PowerShell)
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+```
+
 Install Python dependencies:
 
 ```bash
 pip install -r requirements.txt
+```
+
+When you return later, reactivate it from the project root:
+
+```bash
+source .venv/bin/activate
 ```
 
 Set up environment variables:

--- a/README.md
+++ b/README.md
@@ -1,113 +1,183 @@
 # Agentic Converter
 
-RTL → Diagram pipeline powered by an agentic LLM system (Architect → Auditor → Stylist → DOT Compiler).
+Convert SystemVerilog RTL into architecture diagrams using a multi-agent LLM pipeline:
+
+**Architect -> Auditor -> Stylist -> DOT Compiler -> QuickChart (SVG)**
+
+---
+
+## What It Does
+
+- Accepts RTL source (`.sv`, `.v`, `.svh`, `.vh`) plus optional style instructions
+- Extracts a structured representation of modules/ports/instances
+- Audits structure quality with retry-on-failure (up to 3 attempts)
+- Applies style intent and compiles Graphviz DOT
+- Renders final SVG via QuickChart and serves it through FastAPI
+- Supports iterative regeneration with cumulative style edits
 
 ---
 
 ## Setup
 
-```
+Install Python dependencies:
+
+```bash
 pip install -r requirements.txt
 ```
 
-Copy `.env.example` to `.env` and add your API key:
+Set up environment variables:
+
+```bash
+cp .env.example .env
 ```
+
+Then edit `.env`:
+
+```env
 GOOGLE_API_KEY="your_key_here"
 GOOGLE_MODEL=gemini-2.5-flash
 USE_GEMINI=True
+
+# Optional OpenAI fallback when USE_GEMINI=False
+OPENAI_API_KEY="your_openai_key_here"
+OPENAI_MODEL="gpt-4o-mini"
 ```
+
+> Note: the template file is currently named `.env.example` in this repository.
 
 ---
 
-## Running the app
+## Running the App
 
-Run both servers from the **project root**.
+Run both services from the project root.
 
-**Backend** (FastAPI on port 8000):
-```
-uvicorn backend.app:app --reload --port 8000
+Backend (`FastAPI`, port `8000`):
+
+```bash
+uv run uvicorn backend.app:app --reload --port 8000
 ```
 
-**Frontend** (Next.js on port 3000):
-```
+Frontend (`Next.js`, port `3000`):
+
+```bash
 cd frontend
+npm install
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) in your browser.
+Open [http://localhost:3000](http://localhost:3000).
 
 ---
 
-## Running the pipeline directly
+## API Endpoints
 
-```
-python -m orchestrator.orchestrator
-```
-
-Reads `agents/converter_agent/data/raw/top.sv` and writes `output.svg` to the project root.
-
----
-
-## Tests
-
-```
-python -m pytest tests/ -v              # fast tests (default)
-python -m pytest tests/ -v -s -m slow  # LLM self-correction tests (requires API key)
-```
-
-See [tests/README.md](tests/README.md) for the full test guide.
+- `POST /upload-rtl`
+  - Multipart form: `rtl_file` + optional `customization_text`
+  - Runs full pipeline and returns `{ task_id, svg_url }`
+- `POST /regenerate/{task_id}`
+  - JSON body: `{ "edit_prompt": "..." }`
+  - Regenerates diagram from prior task with cumulative style intent
+  - Returns a new `{ task_id, svg_url }`
+- `GET /task/{task_id}/dot`
+  - Returns DOT source for interactive viewer usage
+- `GET /static/output/{task_id}.svg`
+  - Serves generated SVG assets
 
 ---
 
-## Architecture
+## Pipeline Flow
 
+```text
+Upload RTL + optional style request
+              |
+              v
+Architect: RTL -> RTLStructure JSON
+              |
+              v
+Auditor: validate JSON vs RTL
+    | valid                     | invalid
+    v                           v
+continue                 feedback -> Architect retry (max 3)
+              |
+              v
+Stylist: user prompt -> StyleConfig
+              |
+              v
+DOT Compiler: verified_json + style_map -> DOT
+              |
+              v
+QuickChart Graphviz API: DOT -> SVG
+              |
+              v
+FastAPI returns svg_url + task state
 ```
+
+---
+
+## Repository Structure
+
+```text
 agentic_converter/
-├── backend/
-│   └── app.py                  — FastAPI server (POST /upload-rtl, POST /regenerate/{id})
-├── frontend/
-│   └── app/
-│       ├── page.tsx            — Upload page (RTL file input + style prompt)
-│       └── diagram-review/
-│           └── page.tsx        — Diagram viewer (SVG output + re-style input)
-├── orchestrator/
-│   └── orchestrator.py         — LangGraph pipeline: wires agents together and runs the retry loop
 ├── agents/
-│   └── converter_agent/
-│       ├── config.py           — LLM setup (Gemini/OpenAI switch, prompt loader)
-│       ├── rtl_to_json_agent.py    — Architect: RTL → structured JSON
-│       ├── rtl_and_json_auditor_agent.py — Auditor: verifies JSON matches RTL
-│       ├── stylist_agent.py        — Stylist: maps user style requests to components
-│       ├── dot_compiler_agent.py   — DOT Compiler: JSON + styles → Graphviz DOT
-│       ├── prompts.md          — Architect, Auditor, Stylist prompts
-│       ├── diagram_spec.md     — DOT Compiler prompt + rendering rules
-│       └── tools/
-│           ├── json_schema.py      — RTLStructure Pydantic schema (Architect output)
-│           ├── auditor_schema.py   — AuditReport Pydantic schema (Auditor output)
-│           ├── style_schema.py     — StyleConfig Pydantic schema (Stylist output)
-│           └── rtl_extractor.py    — RTL parsing utilities
+│   ├── config.py                 # LLM selection + prompt section loader
+│   ├── architect/
+│   │   ├── agent.py              # RTL -> RTLStructure
+│   │   ├── schema.py
+│   │   └── prompt.md
+│   ├── auditor/
+│   │   ├── agent.py              # JSON audit report (is_valid + feedback)
+│   │   ├── schema.py
+│   │   └── prompt.md
+│   ├── stylist/
+│   │   ├── agent.py              # StyleConfig generation
+│   │   ├── schema.py
+│   │   └── prompt.md
+│   └── dot_compiler/
+│       ├── agent.py              # verified_json + style_map -> DOT text
+│       └── prompt.md
+├── orchestrator/
+│   └── orchestrator.py           # LangGraph state graph + artifact persistence
+├── backend/
+│   └── app.py                    # FastAPI routes and in-memory task store
 ├── tools/
-│   └── graphviz_quickchart.py  — HTTP client: sends DOT to QuickChart, returns SVG
-├── tests/                      — See tests/README.md
-├── core/                       — Shared base classes (base_agent, state)
+│   └── graphviz_quickchart.py    # DOT -> SVG HTTP client + error handling
+├── frontend/
+│   ├── app/page.tsx              # Upload workflow
+│   ├── app/diagram-review/page.tsx
+│   └── public/viewer.html        # Interactive diagram viewer
+├── tests/
+│   ├── test_json_schema.py
+│   ├── test_json_retry_loop.py
+│   ├── test_json_llm_self_correction.py
+│   ├── test_graphviz_quickchart.py
+│   └── README.md
 ├── requirements.txt
-└── pyproject.toml              — Pytest config (registers 'slow' marker)
+└── uv.lock
 ```
 
-### Pipeline flow
+---
 
+## Testing
+
+Run from project root:
+
+```bash
+# Default fast suite
+python -m pytest tests/ -v
+
+# Only slow LLM self-correction tests
+python -m pytest tests/ -v -s -m slow
+
+# Run all tests including slow
+python -m pytest tests/ -v -m ''
 ```
-User uploads RTL + style prompt
-        ↓
-[Architect] RTL → JSON (RTLStructure)
-        ↓
-[Auditor]  JSON valid? ──No──→ feedback → retry Architect (up to 3x)
-        ↓ Yes
-[Stylist]  style prompt → StyleConfig
-        ↓
-[DOT Compiler] JSON + StyleConfig → DOT source
-        ↓
-[QuickChart]   DOT → SVG
-        ↓
-SVG returned to frontend / saved to backend/static/output/
-```
+
+See `tests/README.md` for detailed guidance and test selection.
+
+---
+
+## Notes
+
+- Prompt sections are loaded from each agent's own `prompt.md` by header name (`# ...`) using `load_prompt(...)`.
+- Prompt files use Python `.format(...)`; literal braces in prompt text must be escaped as `{{` and `}}`.
+- Runtime artifacts are written under your temp directory (`/tmp/agentic_converter_runtime/...`) to avoid noisy reloads during development.

--- a/agents/architect/agent.py
+++ b/agents/architect/agent.py
@@ -1,4 +1,4 @@
-from agents.config import _PROMPTS_FILE, get_llm, load_prompt
+from agents.config import _ARCHITECT_PROMPT_FILE, get_llm, load_prompt
 from .schema import RTLStructure
 
 
@@ -10,7 +10,7 @@ def run_architect_agent(rtl_code: str, feedback: str = "") -> RTLStructure:
     llm = get_llm(temperature=0)
     structured_llm = llm.with_structured_output(RTLStructure)
     prompt = load_prompt(
-        _PROMPTS_FILE,
+        _ARCHITECT_PROMPT_FILE,
         "Architect Prompt",
         rtl_code=rtl_code,
         feedback=feedback,

--- a/agents/auditor/agent.py
+++ b/agents/auditor/agent.py
@@ -1,4 +1,4 @@
-from agents.config import _PROMPTS_FILE, get_llm, load_prompt
+from agents.config import _AUDITOR_PROMPT_FILE, get_llm, load_prompt
 from .schema import AuditReport
 
 
@@ -10,7 +10,7 @@ def run_auditor_agent(rtl_code: str, generated_json: str) -> AuditReport:
     llm = get_llm(temperature=0)
     auditor = llm.with_structured_output(AuditReport)
     prompt = load_prompt(
-        _PROMPTS_FILE,
+        _AUDITOR_PROMPT_FILE,
         "Auditor Prompt",
         rtl_code=rtl_code,
         generated_json=generated_json,

--- a/agents/config.py
+++ b/agents/config.py
@@ -18,8 +18,10 @@ else:
     MODEL_NAME = os.getenv("OPENAI_MODEL")
     API_KEY = os.getenv("OPENAI_API_KEY")
 
-_PROMPTS_FILE = Path(__file__).parent / "prompts.md"
-_DIAGRAM_SPEC_FILE = Path(__file__).parent / "diagram_spec.md"
+_ARCHITECT_PROMPT_FILE = Path(__file__).parent / "architect" / "prompt.md"
+_AUDITOR_PROMPT_FILE   = Path(__file__).parent / "auditor"   / "prompt.md"
+_STYLIST_PROMPT_FILE   = Path(__file__).parent / "stylist"   / "prompt.md"
+_DIAGRAM_SPEC_FILE     = Path(__file__).parent / "dot_compiler" / "prompt.md"
 
 def load_prompt(file_path: str, section: str, **kwargs) -> str:
     """

--- a/agents/stylist/agent.py
+++ b/agents/stylist/agent.py
@@ -1,4 +1,4 @@
-from agents.config import _PROMPTS_FILE, get_llm, load_prompt
+from agents.config import _STYLIST_PROMPT_FILE, get_llm, load_prompt
 from .schema import StyleConfig
 
 
@@ -11,7 +11,7 @@ def run_stylist_agent(architect_json: str, user_request: str) -> StyleConfig:
     llm = get_llm(temperature=0)
     stylist = llm.with_structured_output(StyleConfig)
     prompt = load_prompt(
-        _PROMPTS_FILE,
+        _STYLIST_PROMPT_FILE,
         "Stylist Prompt",
         architect_json=architect_json,
         user_request=user_request,

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,13 +59,13 @@ python -m pytest tests/test_json_llm_self_correction.py::TestLLMSelfCorrectionMi
 ## Test file reference
 
 ### test_json_schema.py
-Tests the Pydantic schemas in `agents/converter_agent/tools/json_schema.py`.
+Tests the Pydantic schemas in `agents/architect/schema.py`.
 No LLM, no agents, runs in under a second.
 
 **When to use:** after changing any schema class (`RTLStructure`, `Port`, `LogicBlock`, `InternalWire`), or to verify that bad JSON from the LLM would be correctly rejected.
 
 **What it covers:**
-- The golden `top_structure.json` parses correctly (sanity baseline)
+- The golden `tests/test_data/top_structure.json` parses correctly (sanity baseline)
 - Missing required fields are rejected
 - Wrong types (int, None, string where list expected) are rejected
 - `LogicBlock` with no `port_mapping` is rejected (the most common LLM failure)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_data/top.sv
+++ b/tests/test_data/top.sv
@@ -1,0 +1,221 @@
+// =============================================================================
+// top.sv
+// RTL Parsing Demo Design
+//
+// Hierarchy:
+//   top
+//   ├── u_ctrl           (ctrl)
+//   ├── u_datapath       (datapath)
+//   ├── u_memory_intf    (memory_intf)
+//   ├── u_fifo           (fifo)
+//   └── u_output_formatter (output_formatter)
+//
+// Connection summary:
+//   top         <-> ctrl, datapath, memory_intf, fifo, output_formatter
+//   ctrl        <-> datapath (start), memory_intf (mem_req, mem_addr)
+//   datapath    <-> memory_intf (mem_data, mem_ack), fifo (wr_en, din, valid)
+//   fifo        <-> output_formatter (rd_en, dout, empty)
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Module: ctrl
+//   Inputs : clk, rst_n, enable, cfg_mode[1:0]
+//   Outputs: start, done, mem_req, mem_addr[7:0]
+// -----------------------------------------------------------------------------
+module ctrl (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        enable,
+    input  logic [1:0]  cfg_mode,
+    output logic        start,
+    output logic        done,
+    output logic        mem_req,
+    output logic [7:0]  mem_addr
+);
+    // stub - no implementation
+endmodule
+
+
+// -----------------------------------------------------------------------------
+// Module: datapath
+//   Inputs : clk, rst_n, start, data_in[7:0], mem_data[7:0], mem_ack
+//   Outputs: data_out[7:0], valid, wr_en
+// -----------------------------------------------------------------------------
+module datapath (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        start,
+    input  logic [7:0]  data_in,
+    input  logic [7:0]  mem_data,
+    input  logic        mem_ack,
+    output logic [7:0]  data_out,
+    output logic        valid,
+    output logic        wr_en
+);
+    // stub - no implementation
+endmodule
+
+
+// -----------------------------------------------------------------------------
+// Module: memory_intf
+//   Inputs : clk, rst_n, mem_req, mem_addr[7:0]
+//   Outputs: mem_data[7:0], mem_ack
+// -----------------------------------------------------------------------------
+module memory_intf (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        mem_req,
+    input  logic [7:0]  mem_addr,
+    output logic [7:0]  mem_data,
+    output logic        mem_ack
+);
+    // stub - no implementation
+endmodule
+
+
+// -----------------------------------------------------------------------------
+// Module: fifo
+//   Inputs : clk, rst_n, wr_en, din[7:0], rd_en
+//   Outputs: dout[7:0], full, empty
+// -----------------------------------------------------------------------------
+module fifo (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic        wr_en,
+    input  logic [7:0]  din,
+    input  logic        rd_en,
+    output logic [7:0]  dout,
+    output logic        full,
+    output logic        empty
+);
+    // stub - no implementation
+endmodule
+
+
+// -----------------------------------------------------------------------------
+// Module: output_formatter
+//   Inputs : clk, rst_n, raw_data[7:0], data_valid, empty
+//   Outputs: result[7:0], result_valid, rd_en
+// -----------------------------------------------------------------------------
+module output_formatter (
+    input  logic        clk,
+    input  logic        rst_n,
+    input  logic [7:0]  raw_data,
+    input  logic        data_valid,
+    input  logic        empty,
+    output logic [7:0]  result,
+    output logic        result_valid,
+    output logic        rd_en
+);
+    // stub - no implementation
+endmodule
+
+
+// -----------------------------------------------------------------------------
+// Module: top
+//   Top-level wrapper.  Instantiates all five sub-modules and wires them
+//   together via internal nets.
+// -----------------------------------------------------------------------------
+module top (
+    // Global clocking / reset
+    input  logic        clk,
+    input  logic        rst_n,
+    // External control inputs
+    input  logic        enable,
+    input  logic [1:0]  cfg_mode,
+    // External data input (to datapath)
+    input  logic [7:0]  data_in,
+    // External outputs
+    output logic        done,
+    output logic [7:0]  result,
+    output logic        result_valid
+);
+
+    // -------------------------------------------------------------------------
+    // Internal signals
+    // -------------------------------------------------------------------------
+
+    // ctrl -> datapath
+    logic        w_start;
+
+    // ctrl -> memory_intf
+    logic        w_mem_req;
+    logic [7:0]  w_mem_addr;
+
+    // memory_intf -> datapath
+    logic [7:0]  w_mem_data;
+    logic        w_mem_ack;
+
+    // datapath -> fifo
+    logic        w_wr_en;
+    logic [7:0]  w_dp_data_out;
+    logic        w_dp_valid;
+
+    // output_formatter -> fifo
+    logic        w_rd_en;
+
+    // fifo -> output_formatter
+    logic [7:0]  w_fifo_dout;
+    logic        w_fifo_full;
+    logic        w_fifo_empty;
+
+    // -------------------------------------------------------------------------
+    // Sub-module instantiations
+    // -------------------------------------------------------------------------
+
+    ctrl u_ctrl (
+        .clk      (clk),
+        .rst_n    (rst_n),
+        .enable   (enable),
+        .cfg_mode (cfg_mode),
+        .start    (w_start),
+        .done     (done),
+        .mem_req  (w_mem_req),
+        .mem_addr (w_mem_addr)
+    );
+
+    datapath u_datapath (
+        .clk      (clk),
+        .rst_n    (rst_n),
+        .start    (w_start),
+        .data_in  (data_in),
+        .mem_data (w_mem_data),
+        .mem_ack  (w_mem_ack),
+        .data_out (w_dp_data_out),
+        .valid    (w_dp_valid),
+        .wr_en    (w_wr_en)
+    );
+
+    memory_intf u_memory_intf (
+        .clk      (clk),
+        .rst_n    (rst_n),
+        .mem_req  (w_mem_req),
+        .mem_addr (w_mem_addr),
+        .mem_data (w_mem_data),
+        .mem_ack  (w_mem_ack)
+    );
+
+    fifo u_fifo (
+        .clk   (clk),
+        .rst_n (rst_n),
+        .wr_en (w_wr_en),
+        .din   (w_dp_data_out),
+        .rd_en (w_rd_en),
+        .dout  (w_fifo_dout),
+        .full  (w_fifo_full),
+        .empty (w_fifo_empty)
+    );
+
+    output_formatter u_output_formatter (
+        .clk          (clk),
+        .rst_n        (rst_n),
+        .raw_data     (w_fifo_dout),
+        .data_valid   (w_dp_valid),
+        .empty        (w_fifo_empty),
+        .result       (result),
+        .result_valid (result_valid),
+        .rd_en        (w_rd_en)
+    );
+
+endmodule
+ 

--- a/tests/test_data/top_structure.json
+++ b/tests/test_data/top_structure.json
@@ -1,0 +1,166 @@
+{
+  "module_name": "top",
+  "top_level_ports": [
+    {
+      "name": "clk",
+      "direction": "input",
+      "width": "1"
+    },
+    {
+      "name": "rst_n",
+      "direction": "input",
+      "width": "1"
+    },
+    {
+      "name": "enable",
+      "direction": "input",
+      "width": "1"
+    },
+    {
+      "name": "cfg_mode",
+      "direction": "input",
+      "width": "2"
+    },
+    {
+      "name": "data_in",
+      "direction": "input",
+      "width": "8"
+    },
+    {
+      "name": "done",
+      "direction": "output",
+      "width": "1"
+    },
+    {
+      "name": "result",
+      "direction": "output",
+      "width": "8"
+    },
+    {
+      "name": "result_valid",
+      "direction": "output",
+      "width": "1"
+    }
+  ],
+  "internal_wires": [
+    {
+      "name": "w_start",
+      "width": "1"
+    },
+    {
+      "name": "w_mem_req",
+      "width": "1"
+    },
+    {
+      "name": "w_mem_addr",
+      "width": "8"
+    },
+    {
+      "name": "w_mem_data",
+      "width": "8"
+    },
+    {
+      "name": "w_mem_ack",
+      "width": "1"
+    },
+    {
+      "name": "w_wr_en",
+      "width": "1"
+    },
+    {
+      "name": "w_dp_data_out",
+      "width": "8"
+    },
+    {
+      "name": "w_dp_valid",
+      "width": "1"
+    },
+    {
+      "name": "w_rd_en",
+      "width": "1"
+    },
+    {
+      "name": "w_fifo_dout",
+      "width": "8"
+    },
+    {
+      "name": "w_fifo_full",
+      "width": "1"
+    },
+    {
+      "name": "w_fifo_empty",
+      "width": "1"
+    }
+  ],
+  "instances": [
+    {
+      "instance_name": "u_ctrl",
+      "module_type": "ctrl",
+      "port_mapping": {
+        "clk": "clk",
+        "rst_n": "rst_n",
+        "enable": "enable",
+        "cfg_mode": "cfg_mode",
+        "start": "w_start",
+        "done": "done",
+        "mem_req": "w_mem_req",
+        "mem_addr": "w_mem_addr"
+      }
+    },
+    {
+      "instance_name": "u_datapath",
+      "module_type": "datapath",
+      "port_mapping": {
+        "clk": "clk",
+        "rst_n": "rst_n",
+        "start": "w_start",
+        "data_in": "data_in",
+        "mem_data": "w_mem_data",
+        "mem_ack": "w_mem_ack",
+        "data_out": "w_dp_data_out",
+        "valid": "w_dp_valid",
+        "wr_en": "w_wr_en"
+      }
+    },
+    {
+      "instance_name": "u_memory_intf",
+      "module_type": "memory_intf",
+      "port_mapping": {
+        "clk": "clk",
+        "rst_n": "rst_n",
+        "mem_req": "w_mem_req",
+        "mem_addr": "w_mem_addr",
+        "mem_data": "w_mem_data",
+        "mem_ack": "w_mem_ack"
+      }
+    },
+    {
+      "instance_name": "u_fifo",
+      "module_type": "fifo",
+      "port_mapping": {
+        "clk": "clk",
+        "rst_n": "rst_n",
+        "wr_en": "w_wr_en",
+        "din": "w_dp_data_out",
+        "rd_en": "w_rd_en",
+        "dout": "w_fifo_dout",
+        "full": "w_fifo_full",
+        "empty": "w_fifo_empty"
+      }
+    },
+    {
+      "instance_name": "u_output_formatter",
+      "module_type": "output_formatter",
+      "port_mapping": {
+        "clk": "clk",
+        "rst_n": "rst_n",
+        "raw_data": "w_fifo_dout",
+        "data_valid": "w_dp_valid",
+        "empty": "w_fifo_empty",
+        "result": "result",
+        "result_valid": "result_valid",
+        "rd_en": "w_rd_en"
+      }
+    }
+  ]
+}

--- a/tests/test_json_llm_self_correction.py
+++ b/tests/test_json_llm_self_correction.py
@@ -24,9 +24,8 @@ from unittest.mock import patch, wraps
 
 import pytest
 
-from agents.converter_agent.tools.json_schema import RTLStructure
-from agents.converter_agent.rtl_to_json_agent import run_architect_agent
-from agents.converter_agent.rtl_and_json_auditor_agent import run_auditor_agent
+from agents.architect.schema import RTLStructure
+from agents.architect.agent import run_architect_agent
 from orchestrator.orchestrator import rtl_to_json_to_dot
 
 
@@ -38,19 +37,18 @@ pytestmark = pytest.mark.slow
 # ── Test data ───────────────────────────────────────────────────────────────
 
 _GOLDEN_PATH = (
-    Path(__file__).parent.parent
-    / "agents" / "converter_agent" / "data" / "processed" / "top_structure.json"
+    Path(__file__).parent / "test_data" / "top_structure.json"
 )
 _GOLDEN = json.loads(_GOLDEN_PATH.read_text(encoding="utf-8"))
 
 _RTL_PATH = (
-    Path(__file__).parent.parent
-    / "agents" / "converter_agent" / "data" / "raw" / "top.sv"
+    Path(__file__).parent / "test_data" / "top.sv"
 )
 _RTL_CODE = _RTL_PATH.read_text(encoding="utf-8")
 
 
-def _make_state() -> dict:
+def _make_state(run_dir: Path) -> dict:
+    (run_dir / "iterations").mkdir(parents=True, exist_ok=True)
     return {
         "rtl_code": _RTL_CODE,
         "user_style_prompt": "no styling",
@@ -59,6 +57,9 @@ def _make_state() -> dict:
         "style_map": None,
         "dot_source": None,
         "svg_output": None,
+        "session_output_dir": str(run_dir.parent),
+        "run_id": run_dir.name,
+        "run_dir": str(run_dir),
     }
 
 
@@ -132,14 +133,14 @@ def _make_corrupted_architect(corrupt_fn):
 class TestLLMSelfCorrectionMissingPorts:
     """Inject JSON with missing port mappings → auditor flags it → LLM fixes it."""
 
-    def test_recovers_from_missing_ports(self):
+    def test_recovers_from_missing_ports(self, tmp_path: Path):
         wrapper, log = _make_corrupted_architect(corrupt_missing_ports)
 
         with patch(
             "orchestrator.orchestrator.run_architect_agent",
             side_effect=wrapper,
         ):
-            result = rtl_to_json_to_dot(_make_state())
+            result = rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         # The LLM should have needed at least 2 attempts
         assert log["count"] >= 2, "Expected retry — auditor should have rejected attempt 1"
@@ -158,14 +159,14 @@ class TestLLMSelfCorrectionMissingPorts:
 class TestLLMSelfCorrectionHallucinatedInstance:
     """Inject a fake instance → auditor flags hallucination → LLM removes it."""
 
-    def test_recovers_from_hallucinated_instance(self):
+    def test_recovers_from_hallucinated_instance(self, tmp_path: Path):
         wrapper, log = _make_corrupted_architect(corrupt_hallucinated_instance)
 
         with patch(
             "orchestrator.orchestrator.run_architect_agent",
             side_effect=wrapper,
         ):
-            result = rtl_to_json_to_dot(_make_state())
+            result = rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         assert log["count"] >= 2
         assert result["verified_json"] is not None
@@ -180,14 +181,14 @@ class TestLLMSelfCorrectionHallucinatedInstance:
 class TestLLMSelfCorrectionWrongWires:
     """Inject wrong wire names → auditor flags them → LLM corrects them."""
 
-    def test_recovers_from_wrong_wire_names(self):
+    def test_recovers_from_wrong_wire_names(self, tmp_path: Path):
         wrapper, log = _make_corrupted_architect(corrupt_wrong_wire_names)
 
         with patch(
             "orchestrator.orchestrator.run_architect_agent",
             side_effect=wrapper,
         ):
-            result = rtl_to_json_to_dot(_make_state())
+            result = rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         assert log["count"] >= 2
         assert result["verified_json"] is not None
@@ -204,14 +205,14 @@ class TestLLMSelfCorrectionWrongWires:
 class TestLLMSelfCorrectionMissingInstance:
     """Remove an instance entirely → auditor flags it → LLM adds it back."""
 
-    def test_recovers_from_missing_instance(self):
+    def test_recovers_from_missing_instance(self, tmp_path: Path):
         wrapper, log = _make_corrupted_architect(corrupt_missing_instance)
 
         with patch(
             "orchestrator.orchestrator.run_architect_agent",
             side_effect=wrapper,
         ):
-            result = rtl_to_json_to_dot(_make_state())
+            result = rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         assert log["count"] >= 2
         assert result["verified_json"] is not None

--- a/tests/test_json_retry_loop.py
+++ b/tests/test_json_retry_loop.py
@@ -15,27 +15,25 @@ Run:
 import json
 from copy import deepcopy
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
-from agents.converter_agent.tools.json_schema import RTLStructure
-from agents.converter_agent.tools.auditor_schema import AuditReport
-from agents.converter_agent.tools.style_schema import StyleConfig, ComponentStyle
+from agents.architect.schema import RTLStructure
+from agents.auditor.schema import AuditReport
+from agents.stylist.schema import StyleConfig
 from orchestrator.orchestrator import rtl_to_json_to_dot, MAX_ATTEMPTS
 
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
 
 _GOLDEN_PATH = (
-    Path(__file__).parent.parent
-    / "agents" / "converter_agent" / "data" / "processed" / "top_structure.json"
+    Path(__file__).parent / "test_data" / "top_structure.json"
 )
 _GOLDEN = json.loads(_GOLDEN_PATH.read_text(encoding="utf-8"))
 
 _RTL_PATH = (
-    Path(__file__).parent.parent
-    / "agents" / "converter_agent" / "data" / "raw" / "top.sv"
+    Path(__file__).parent / "test_data" / "top.sv"
 )
 _RTL_CODE = _RTL_PATH.read_text(encoding="utf-8")
 
@@ -74,7 +72,8 @@ def _empty_style() -> StyleConfig:
     return StyleConfig(module_styles={}, wire_styles={})
 
 
-def _make_state(rtl_code: str = _RTL_CODE) -> dict:
+def _make_state(run_dir: Path, rtl_code: str = _RTL_CODE) -> dict:
+    (run_dir / "iterations").mkdir(parents=True, exist_ok=True)
     return {
         "rtl_code": rtl_code,
         "user_style_prompt": "no styling",
@@ -83,6 +82,9 @@ def _make_state(rtl_code: str = _RTL_CODE) -> dict:
         "style_map": None,
         "dot_source": None,
         "svg_output": None,
+        "session_output_dir": str(run_dir.parent),
+        "run_id": run_dir.name,
+        "run_dir": str(run_dir),
     }
 
 
@@ -98,7 +100,7 @@ _DOT = "orchestrator.orchestrator.run_dot_compiler_agent"
 class TestRetryOnAuditorRejection:
     """Auditor rejects the JSON, loop retries with feedback, then succeeds."""
 
-    def test_fails_once_then_passes(self):
+    def test_fails_once_then_passes(self, tmp_path: Path):
         """Attempt 1: auditor rejects (missing ports). Attempt 2: passes."""
         bad_struct = _bad_rtl_structure_missing_ports()
         good_struct = _good_rtl_structure()
@@ -115,7 +117,7 @@ class TestRetryOnAuditorRejection:
             patch(_STYLE, return_value=_empty_style()),
             patch(_DOT, return_value="digraph top {}"),
         ):
-            result = rtl_to_json_to_dot(_make_state())
+            result = rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         # Architect was called twice (attempt 1 failed, attempt 2 passed)
         assert mock_arch.call_count == 2
@@ -130,7 +132,7 @@ class TestRetryOnAuditorRejection:
         assert result["verified_json"] is not None
         assert result["dot_source"] == "digraph top {}"
 
-    def test_fails_twice_then_passes(self):
+    def test_fails_twice_then_passes(self, tmp_path: Path):
         """Attempts 1 & 2: auditor rejects. Attempt 3: passes."""
         bad = _bad_rtl_structure_missing_ports()
         good = _good_rtl_structure()
@@ -142,7 +144,7 @@ class TestRetryOnAuditorRejection:
             patch(_STYLE, return_value=_empty_style()),
             patch(_DOT, return_value="digraph top {}"),
         ):
-            result = rtl_to_json_to_dot(_make_state())
+            result = rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         assert mock_arch.call_count == 3
         assert mock_audit.call_count == 3
@@ -152,7 +154,7 @@ class TestRetryOnAuditorRejection:
 class TestRetryOnArchitectException:
     """Architect raises an exception, loop catches it and retries."""
 
-    def test_architect_crashes_once_then_recovers(self):
+    def test_architect_crashes_once_then_recovers(self, tmp_path: Path):
         """Attempt 1: architect throws. Attempt 2: succeeds."""
         good = _good_rtl_structure()
 
@@ -165,21 +167,21 @@ class TestRetryOnArchitectException:
             patch(_STYLE, return_value=_empty_style()),
             patch(_DOT, return_value="digraph top {}"),
         ):
-            result = rtl_to_json_to_dot(_make_state())
+            result = rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         # Architect called twice, but auditor only once (skipped on crash)
         assert mock_arch.call_count == 2
         assert mock_audit.call_count == 1
         assert result["verified_json"] is not None
 
-    def test_architect_crashes_all_attempts(self):
+    def test_architect_crashes_all_attempts(self, tmp_path: Path):
         """Architect throws on every attempt → pipeline raises RuntimeError."""
         with (
             patch(_ARCH, side_effect=ValueError("bad output")) as mock_arch,
             patch(_AUDIT) as mock_audit,
         ):
             with pytest.raises(RuntimeError, match="could not produce valid JSON"):
-                rtl_to_json_to_dot(_make_state())
+                rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         assert mock_arch.call_count == MAX_ATTEMPTS
         assert mock_audit.call_count == 0  # never reached
@@ -188,7 +190,7 @@ class TestRetryOnArchitectException:
 class TestAllAttemptsExhausted:
     """Auditor rejects every attempt → pipeline gives up."""
 
-    def test_max_attempts_then_raises(self):
+    def test_max_attempts_then_raises(self, tmp_path: Path):
         bad = _bad_rtl_structure_missing_ports()
         fail = _failing_audit(["u_ctrl.rst_n"], "still missing ports")
 
@@ -197,7 +199,7 @@ class TestAllAttemptsExhausted:
             patch(_AUDIT, return_value=fail) as mock_audit,
         ):
             with pytest.raises(RuntimeError, match="could not produce valid JSON"):
-                rtl_to_json_to_dot(_make_state())
+                rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         assert mock_arch.call_count == MAX_ATTEMPTS
         assert mock_audit.call_count == MAX_ATTEMPTS
@@ -206,7 +208,7 @@ class TestAllAttemptsExhausted:
 class TestPassesOnFirstAttempt:
     """Happy path: architect nails it on attempt 1."""
 
-    def test_no_retries_needed(self):
+    def test_no_retries_needed(self, tmp_path: Path):
         good = _good_rtl_structure()
 
         with (
@@ -215,7 +217,7 @@ class TestPassesOnFirstAttempt:
             patch(_STYLE, return_value=_empty_style()),
             patch(_DOT, return_value="digraph top {}"),
         ):
-            result = rtl_to_json_to_dot(_make_state())
+            result = rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         assert mock_arch.call_count == 1
         assert mock_audit.call_count == 1
@@ -227,7 +229,7 @@ class TestFeedbackContent:
     """Verify that the feedback string passed to the architect contains
     the auditor's message so the LLM knows what to fix."""
 
-    def test_auditor_feedback_forwarded_to_architect(self):
+    def test_auditor_feedback_forwarded_to_architect(self, tmp_path: Path):
         bad = _bad_rtl_structure_missing_ports()
         good = _good_rtl_structure()
         specific_feedback = "u_ctrl is missing port mappings for rst_n, enable, cfg_mode"
@@ -241,7 +243,7 @@ class TestFeedbackContent:
             patch(_STYLE, return_value=_empty_style()),
             patch(_DOT, return_value="digraph top {}"),
         ):
-            rtl_to_json_to_dot(_make_state())
+            rtl_to_json_to_dot(_make_state(run_dir=tmp_path / "run"))
 
         # The second call to the architect should include the auditor's feedback
         second_call = mock_arch.call_args_list[1]

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,4 +1,4 @@
-"""Tests for the RTLStructure schema (agents/converter_agent/tools/json_schema.py).
+"""Tests for the RTLStructure schema (agents/architect/schema.py).
 
 Focus: invalid / malformed JSON that the Architect agent might produce.
 Each test targets a single field or constraint so failures point directly
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from agents.converter_agent.tools.json_schema import (
+from agents.architect.schema import (
     InternalWire,
     LogicBlock,
     Port,
@@ -22,10 +22,7 @@ from agents.converter_agent.tools.json_schema import (
 # ── Golden reference ────────────────────────────────────────────────────────
 # Load the known-good structure so we can corrupt one field at a time.
 
-_GOLDEN_PATH = (
-    Path(__file__).parent.parent
-    / "agents" / "converter_agent" / "data" / "processed" / "top_structure.json"
-)
+_GOLDEN_PATH = Path(__file__).parent / "test_data" / "top_structure.json"
 _GOLDEN = json.loads(_GOLDEN_PATH.read_text(encoding="utf-8"))
 
 


### PR DESCRIPTION
- Rewrote main README.md file.
- Updated README.md file in tests folder to ensure file consistency.
- Updated import statements to remove "agentic_converter..." due to refactor #36.
- Added a new folder: tests/test_data/ to include top.sv and json file for testing. 
- Added conftest.py file to hold the project root and avoid hitting a `ModuleNotFoundError`.
- Updated the directories where test outputs are stored. Previously they were stored locally on system where would they would not auto delete. Now we are using `tmp_path` which is what `pytest` looks at to store temporary files. 
- Add example for .env